### PR TITLE
Use GtkStackSwitcher instead of GtkButtonBox

### DIFF
--- a/ui/altlibrary.ui
+++ b/ui/altlibrary.ui
@@ -7,11 +7,10 @@
     <property name="can_focus">False</property>
     <property name="homogeneous">True</property>
     <child>
-      <object class="GtkButtonBox" id="buttonbox1">
+      <object class="GtkStackSwitcher" id="buttonbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="homogeneous">True</property>
-        <property name="layout_style"/>
         <child>
           <object class="GtkRadioButton" id="library_song_radiobutton">
             <property name="label" translatable="yes">Songs</property>


### PR DESCRIPTION
Another apps like gnome-system-monitor use GtkStackSwitcher on their headerbar, so I think it will be better if this plugin also use GtkStackSwitcher instead of GtkButtonBox. 

* sorry for bad english