### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ $ ebuild alternative-toolbar-9999.ebuild digest
 $ emerge alternative-toolbar
 ```
 
-##To uninstall.
+## To uninstall.
 
 If installed via Git you need the original code to uninstall the plugin.
 ```bash


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
