### PR TITLE
Add gi module before using gi.require_version

### DIFF
--- a/alternative-toolbar.py
+++ b/alternative-toolbar.py
@@ -19,6 +19,7 @@
 # define plugin
 
 import rb
+import gi
 from gi.repository import GObject
 from gi.repository import Gio
 from gi.repository import Gtk

--- a/alttoolbar_preferences.py
+++ b/alttoolbar_preferences.py
@@ -25,6 +25,7 @@ import shutil
 import sys
 
 import rb
+import gi
 from gi.repository import GObject
 from gi.repository import Gio
 from gi.repository import Gtk


### PR DESCRIPTION
Rhythmbox fails to load the plugin if the gi module is not imported.