### PR TITLE
Add home install option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,8 +3,6 @@
 	$(MKDIR_P) "$(dir $@)"; \
 	$(INTLTOOL_MERGE) $(top_srcdir)/po $< $@ -d -u -c $(top_builddir)/po/.intltool-merge-cache
 
-rb_plugin_libdir = $(libdir)/rhythmbox/plugins/alternative-toolbar
-
 SUBDIRS = po
 
 CLEANFILES = \
@@ -18,7 +16,7 @@ CLEANFILES = \
 	./m4/intltool.m4
 
 DISTCLEANFILES = \
-    ChangeLog \
+	ChangeLog \
 	alternative-toolbar.plugin \
 	./po/.intltool-merge-cache \
 	./po/Makefile \
@@ -68,6 +66,7 @@ EXTRA_DIST = \
 	LICENSE \
 	$(METAINFO_FILES)
 
+rb_plugin_libdir = $(libdir)/rhythmbox/plugins/alternative-toolbar
 rb_plugin_lib_DATA = \
 	$(PLUGIN_FILES) \
 	alternative-toolbar.plugin
@@ -80,14 +79,18 @@ rb_plugin_uidir = $(datadir)/rhythmbox/plugins/alternative-toolbar/ui
 rb_plugin_ui_DATA = \
 	$(UI_FILES)
 
-gsettings_SCHEMAS = \
-	schema/org.gnome.rhythmbox.plugins.alternative_toolbar.gschema.xml
-	
 rb_plugin_metainfodir = $(datadir)/metainfo
 rb_plugin_metainfo_DATA = \
 	$(METAINFO_FILES)
 
+gsettings_SCHEMAS = \
+	schema/org.gnome.rhythmbox.plugins.alternative_toolbar.gschema.xml
+
 @GSETTINGS_RULES@
+
+uninstall-hook:
+	-rmdir -p --ignore-fail-on-non-empty $(am__installdirs) $(gsettingsschemadir)
+	-find $(localedir) -type d -empty -delete
 
 CHANGELOG_START = v0.14.0
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,18 @@ version of the plugin, remove it:
 rm -rf ~/.local/share/rhythmbox/plugins/alternative-toolbar
 ```
 
+### Install in the home directory from Git
+
+```bash
+cd ~/Downloads
+sudo apt-get install intltool git gir1.2-glib-2.0 gir1.2-gstreamer-1.0 gir1.2-gtk-3.0 gir1.2-peas-1.0 gir1.2-rb-3.0 gnome-pkg-tools gobject-introspection libglib2.0-dev pkg-config python3-gi python3
+git clone https://github.com/fossfreedom/alternative-toolbar.git
+cd alternative-toolbar
+./autogen.sh --with-home-install
+make
+make install
+```
+
 ### Ubuntu PPA - latest stable release
 
 If you are using Ubuntu you can install alternative-toolbar via a

--- a/autogen.sh
+++ b/autogen.sh
@@ -9,16 +9,20 @@ PKG_NAME="alternative-toolbar"
 prevdir="$PWD"
 cd "$srcdir"
 
+INTLTOOLIZE=`which intltoolize`
+if test -z $INTLTOOLIZE; then
+  echo "*** No intltoolize found, please install the intltool package ***"
+  exit 1
+fi
 
-intltoolize --force
 AUTORECONF=`which autoreconf`
-if test -z $AUTORECONF;
-then
+if test -z $AUTORECONF; then
   echo "*** No autoreconf found, please install it ***"
   exit 1
-else
-  autoreconf --force --install || exit $?
 fi
+
+intltoolize --force
+autoreconf --force --install || exit $?
 
 cd "$prevdir"
 test -n "$NOCONFIGURE" || "$srcdir/configure" "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,12 @@
-AC_INIT([alternative-toolbar], 0.19.3, [fossfreedom@ubuntu.com],
-[alternative-toolbar], [https://github.com/fossfreedom/alternative-toolbar])
+AC_INIT([Alternative Toolbar],
+        [0.19.3],
+        [fossfreedom@ubuntu.com],
+        [alternative-toolbar],
+        [https://github.com/fossfreedom/alternative-toolbar])
+AC_CONFIG_SRCDIR([alternative-toolbar.plugin.in])
 AM_INIT_AUTOMAKE([-Wno-portability no-dist-gzip dist-xz foreign subdir-objects])
-AC_PREFIX_DEFAULT(/usr/local)
+AC_PREFIX_DEFAULT(/usr)
+AC_PREFIX_PROGRAM(rhythmbox)
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([m4])
 
@@ -17,6 +22,15 @@ AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",
                    [The prefix for gettext translation domains.])
 
 AM_GLIB_GNU_GETTEXT
+
+AC_ARG_WITH(home-install,
+            AC_HELP_STRING([--with-home-install],
+                           [Install alternative-toolbar in the home directory (~/.local/share/rhythmbox/plugins)]))
+if test "x$with_home_install" = "xyes"; then
+       prefix=~/.local/share
+       libdir=${prefix}
+       datarootdir=${prefix}
+fi
 
 # Pythonic checks
 AM_PATH_PYTHON([3.2])


### PR DESCRIPTION
This PR adds an option to install alternative-toolbar in the home directory (`~/.local/share/rhythmbox/plugins`).

This can be done with:
```
./autogen.sh --with-home-install
make
make install
```

Closes #91 