### PR TITLE
Set r prefix in regex

### DIFF
--- a/alttoolbar_plugins.py
+++ b/alttoolbar_plugins.py
@@ -168,7 +168,7 @@ class PluginDialog(Gtk.Dialog):
         def extract_text(str):
             # remove _ and (_A) type expressions
             translation = gettext.gettext(str)
-            translation = re.sub('\(..\)', '', translation, flags=re.DOTALL)
+            translation = re.sub(r'\(..\)', '', translation, flags=re.DOTALL)
             translation = translation.replace('_', '')
             return translation
 


### PR DESCRIPTION
This is a tiny change, and it just removes a syntax warning from appearing.

Setting "r" string prefix in the regex removes the following warning, visible e.g. when installing from apt on ubuntu:

`<stdin>:1: SyntaxWarning: invalid escape sequence '\('`